### PR TITLE
Fix `get_charset_collate` usage

### DIFF
--- a/inc/log/namespace.php
+++ b/inc/log/namespace.php
@@ -37,7 +37,7 @@ function create_table() : void {
 		`status` varchar(50) NOT NULL,
 		`data` longtext,
 		PRIMARY KEY (`id`)
-	) ENGINE=InnoDB DEFAULT CHARSET={$charset_collate};\n";
+	) ENGINE=InnoDB {$charset_collate};\n";
 
 	$result = $wpdb->query( $query );
 }


### PR DESCRIPTION
The `get_charset_collate` method returns the full character set and collation string for create table calls. This update removes the duplicated part of the query so the query doesn't report a syntax error.

https://developer.wordpress.org/reference/classes/wpdb/get_charset_collate/#source

Fixes #4 